### PR TITLE
feat: Add dark mode functionality

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,13 +8,41 @@ let prioritySortOrder = 'desc'; // 'desc' (High->Low) or 'asc' (Low->High)
 const todoInput = document.getElementById('todoInput');
 const todoList = document.getElementById('todoList');
 const prioritySelect = document.getElementById('prioritySelect');
-const filterButtons = document.querySelectorAll('.filter-btn:not(#sortPriorityBtn)'); // Exclude sort button
+const filterButtons = document.querySelectorAll('.filter-btn:not(#sortPriorityBtn):not(#darkModeToggleBtn)'); // Exclude sort and dark mode buttons
 const sortPriorityBtn = document.getElementById('sortPriorityBtn');
+const darkModeToggleBtn = document.getElementById('darkModeToggleBtn'); // Dark mode button
 
-// 페이지 로드 시 저장된 할 일 목록 불러오기
+// --- Dark Mode Functions ---
+function applyTheme(theme) {
+    if (theme === 'dark') {
+        document.body.classList.add('dark-mode');
+        if (darkModeToggleBtn) darkModeToggleBtn.textContent = '라이트 모드';
+    } else {
+        document.body.classList.remove('dark-mode');
+        if (darkModeToggleBtn) darkModeToggleBtn.textContent = '다크 모드';
+    }
+}
+
+function toggleDarkMode() {
+    const currentTheme = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
+    localStorage.setItem('theme', currentTheme);
+    applyTheme(currentTheme);
+}
+
+function loadThemePreference() {
+    const savedTheme = localStorage.getItem('theme') || 'light'; // Default to light
+    applyTheme(savedTheme);
+}
+// --- End Dark Mode Functions ---
+
+// 페이지 로드 시 저장된 할 일 목록 및 테마 불러오기
 document.addEventListener('DOMContentLoaded', () => {
     loadTodos();
-    renderTodos();
+    if (darkModeToggleBtn) { // Ensure button exists before adding listener or loading theme
+        loadThemePreference();
+        darkModeToggleBtn.addEventListener('click', toggleDarkMode);
+    }
+    renderTodos(); // Initial render after loading todos and theme
 });
 
 // 할 일 추가 함수

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
             <button class="filter-btn" onclick="filterTodos('active')">할 일</button>
             <button class="filter-btn" onclick="filterTodos('completed')">완료</button>
             <button id="sortPriorityBtn" class="filter-btn" onclick="toggleSortByPriority()">우선순위 정렬</button>
+            <button id="darkModeToggleBtn" class="filter-btn">다크 모드</button>
         </div>
         <ul id="todoList">
             <!-- 할 일 항목들이 여기에 추가됩니다 -->

--- a/styles.css
+++ b/styles.css
@@ -205,3 +205,85 @@ h1 {
         margin-right: 5px;
     }
 }
+
+/* Dark Mode Styles */
+body.dark-mode {
+    background-color: #1a1a1a; /* Darker background */
+    color: #e0e0e0; /* Lighter text */
+}
+
+.dark-mode .container {
+    background-color: #2c2c2c; /* Dark container background */
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5); /* Adjusted shadow for dark mode */
+}
+
+.dark-mode h1 {
+    color: #e0e0e0; /* Lighter h1 text */
+}
+
+.dark-mode .todo-input input[type="text"],
+.dark-mode #prioritySelect {
+    background-color: #333333; /* Dark input background */
+    color: #e0e0e0; /* Light input text */
+    border-color: #555555; /* Darker border */
+}
+
+.dark-mode .todo-input button {
+    background-color: #005f73; /* Darker button background */
+    color: #e0e0e0;
+}
+
+.dark-mode .todo-input button:hover {
+    background-color: #007f99;
+}
+
+.dark-mode .filter-btn {
+    background-color: #444444; /* Dark filter button background */
+    color: #e0e0e0; /* Light filter button text */
+}
+
+.dark-mode .filter-btn.active {
+    background-color: #007f99; /* Active filter button in dark mode */
+    color: #ffffff;
+}
+
+.dark-mode .filter-btn:hover {
+    background-color: #555555;
+}
+
+.dark-mode .todo-item {
+    background-color: #333333; /* Dark todo item background */
+    color: #e0e0e0; /* Light todo item text */
+}
+
+.dark-mode .todo-item.completed {
+    background-color: #444444; /* Dark completed todo item */
+    color: #aaaaaa; /* Adjusted completed text color */
+}
+
+.dark-mode .todo-item .delete-btn {
+    background-color: #9b2226; /* Darker delete button */
+    color: #e0e0e0;
+}
+
+.dark-mode .todo-item .delete-btn:hover {
+    background-color: #ae2012;
+}
+
+/* Priority colors in dark mode - assuming text is light, adjust background for contrast */
+.dark-mode .todo-priority.priority-high {
+    background-color: #bb3e03; /* Darker red */
+}
+
+.dark-mode .todo-priority.priority-medium {
+    background-color: #ca6702; /* Darker orange */
+}
+
+.dark-mode .todo-priority.priority-low {
+    background-color: #218838; /* Darker green */
+}
+
+.dark-mode #prioritySelect {
+    background-color: #333333; /* Ensure select has dark background */
+    color: #e0e0e0; /* Ensure select has light text */
+}

--- a/test.html
+++ b/test.html
@@ -29,6 +29,7 @@
         <button class="filter-btn" onclick="filterTodos('active')">할 일</button>
         <button class="filter-btn" onclick="filterTodos('completed')">완료</button>
         <button id="sortPriorityBtn" class="filter-btn" onclick="toggleSortByPriority()">우선순위 정렬</button>
+        <button id="darkModeToggleBtn" class="filter-btn">다크 모드</button> 
     </div>
 
     <ul id="todoList"></ul>
@@ -305,6 +306,88 @@
             logMessage(`Finished test: ${testName}`);
         }
 
+        function resetDarkModeState() {
+            logMessage('Resetting dark mode state...');
+            document.body.classList.remove('dark-mode');
+            localStorage.removeItem('theme');
+            // Ensure button text is reset if app.js's loadThemePreference isn't called immediately after
+            // darkModeToggleBtn is globally available from app.js after DOMContentLoaded
+            if (typeof darkModeToggleBtn !== 'undefined' && darkModeToggleBtn) { 
+                 darkModeToggleBtn.textContent = '다크 모드';
+            }
+            // We need to ensure app.js's internal state for theme also resets,
+            // so calling loadThemePreference() is good.
+            if (typeof loadThemePreference === 'function') {
+                loadThemePreference(); // This will set it to light by default if no local storage
+            }
+            logMessage('Dark mode state reset.');
+        }
+
+        function testDarkModeFeature() {
+            const testName = "Dark Mode Feature";
+            logMessage(`Starting test: ${testName}`);
+            // const darkModeToggleBtn = document.getElementById('darkModeToggleBtn'); // This is made global by app.js
+            const body = document.body;
+
+            if (typeof darkModeToggleBtn === 'undefined' || !darkModeToggleBtn) {
+                logTestResult(testName, "Failed: darkModeToggleBtn not found. Ensure app.js has loaded and initialized it. Cannot run tests.", false);
+                return;
+            }
+
+            // --- Test 1 & 2: Toggle Functionality and Button Text Update ---
+            logMessage(`${testName} - Testing Toggle and Button Text`);
+            resetDarkModeState(); 
+
+            assertEquals(body.classList.contains('dark-mode'), false, `${testName} - Initial: Body should not have dark-mode class`);
+            // Check initial text after resetDarkModeState ensures loadThemePreference has run
+            assertEquals(darkModeToggleBtn.textContent, '다크 모드', `${testName} - Initial: Button text should be '다크 모드'`);
+
+            darkModeToggleBtn.click(); // Activate dark mode
+            assertIsTrue(body.classList.contains('dark-mode'), `${testName} - Toggle On: Body has dark-mode class`);
+            assertEquals(darkModeToggleBtn.textContent, '라이트 모드', `${testName} - Toggle On: Button text is '라이트 모드'`);
+
+            darkModeToggleBtn.click(); // Deactivate dark mode
+            assertIsTrue(!body.classList.contains('dark-mode'), `${testName} - Toggle Off: Body does not have dark-mode class`);
+            assertEquals(darkModeToggleBtn.textContent, '다크 모드', `${testName} - Toggle Off: Button text is '다크 모드'`);
+
+            // --- Test 3: Local Storage Persistence ---
+            logMessage(`${testName} - Testing Local Storage Persistence`);
+            resetDarkModeState();
+
+            darkModeToggleBtn.click(); // Activate dark mode
+            assertEquals(localStorage.getItem('theme'), 'dark', `${testName} - LocalStorage: 'dark' after activation`);
+
+            darkModeToggleBtn.click(); // Deactivate dark mode
+            assertEquals(localStorage.getItem('theme'), 'light', `${testName} - LocalStorage: 'light' after deactivation`);
+
+            // --- Test 4: Initial Load from Local Storage ---
+            logMessage(`${testName} - Testing Initial Load from Local Storage`);
+
+            // Test 4.1: Load Dark Theme
+            resetDarkModeState(); // Clears theme, body class, and calls loadThemePreference
+            localStorage.setItem('theme', 'dark');
+            loadThemePreference(); // Simulate page load by calling the function from app.js
+            assertIsTrue(body.classList.contains('dark-mode'), `${testName} - Load Dark: Body has dark-mode class`);
+            assertEquals(darkModeToggleBtn.textContent, '라이트 모드', `${testName} - Load Dark: Button text is '라이트 모드'`);
+            
+            // Test 4.2: Load Light Theme
+            resetDarkModeState();
+            localStorage.setItem('theme', 'light');
+            loadThemePreference();
+            assertIsTrue(!body.classList.contains('dark-mode'), `${testName} - Load Light: Body does not have dark-mode class`);
+            assertEquals(darkModeToggleBtn.textContent, '다크 모드', `${testName} - Load Light: Button text is '다크 모드'`);
+
+            // Test 4.3: Load Default Theme (no local storage)
+            resetDarkModeState(); // This already removes 'theme' from localStorage and calls loadThemePreference
+            loadThemePreference(); // Call again to be sure, though resetDarkModeState should handle it
+            assertIsTrue(!body.classList.contains('dark-mode'), `${testName} - Load Default: Body does not have dark-mode class (default light)`);
+            assertEquals(darkModeToggleBtn.textContent, '다크 모드', `${testName} - Load Default: Button text is '다크 모드' (default light)`);
+
+            // Final cleanup
+            resetDarkModeState();
+            logMessage(`Finished test: ${testName}`);
+        }
+
 
         // --- Run all tests ---
         function runAllTests() {
@@ -314,7 +397,8 @@
                 testSaveAndLoadPriority,
                 testBackwardCompatibilityLoad,
                 testSortByPriority,
-                testFilterAndSortInteraction
+                testFilterAndSortInteraction,
+                testDarkModeFeature // Added new test function
             ];
 
             allTestCases.forEach(testCase => {


### PR DESCRIPTION
This commit introduces a dark mode feature to the To-Do List application.

Key changes:
- Added a toggle button in `index.html` to switch between light and dark modes.
- Defined dark mode styles in `styles.css` for various UI elements, ensuring better readability in low-light environments.
- Implemented JavaScript logic in `app.js` to:
    - Handle the theme toggling.
    - Update the toggle button text based on the current mode.
    - Store your theme preference in `localStorage`.
    - Load and apply the saved theme preference on page load, defaulting to light mode if no preference is set.
- Added comprehensive tests in `test.html` to cover:
    - Theme toggling functionality.
    - Correct button text updates.
    - Persistence of theme preference in `localStorage`.
    - Correct application of theme on initial page load based on `localStorage`.