### PR TITLE
feat: 할 일 항목에 상태 필드 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,11 @@
                 <option value="medium" selected>Medium</option>
                 <option value="low">Low</option>
             </select>
+            <select id="statusSelect">
+                <option value="pending">대기중</option>
+                <option value="inprogress">진행중</option>
+                <option value="completed">완료</option>
+            </select>
             <button onclick="addTodo()">추가</button>
         </div>
         <div class="filters">


### PR DESCRIPTION
- '대기중', '진행중', '완료' 상태 옵션을 가진 상태 선택 드롭다운을 추가합니다.
- 할 일 객체에 'status' 속성을 도입하고, 기존 'completed' 속성을 대체합니다.
- 당신은 할 일 추가 시 상태를 선택할 수 있습니다.
- 체크박스를 통해 할 일 상태를 '완료' 또는 '진행중'으로 토글할 수 있습니다.
- 필터링 로직('할 일', '완료')을 새로운 상태 시스템에 맞게 업데이트합니다.
- 기존 로컬 스토리지 데이터를 새로운 상태 시스템으로 마이그레이션합니다.